### PR TITLE
Adding support for CDATA elements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "mocha": true
   },
   "rules": {
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "no-underscore-dangle": "warn"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+
+# IntelliJ Idea Project fikes
+.idea

--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ fattura24.saveCustomer({
 });
 ```
 
+
+#### Create a new customer with special chars
+
+In case of special chars, like the ampersand (&) Fattura24 requires to escape them in an XML cdata.
+One way to do it is to pass a subobject with the _cdata field to the properties.
+
+Right now the project automatically converts the _cdata returning from the xml, but doesn't autoconvert properties while
+sending them, therefore it's advised to add the _cdata in all needed fields.
+
+Example:      
+```js
+var fattura24 = new Fattura24({ apiKey: 'weejeighaGushuz7Megeisheij6oogh3' });
+
+fattura24.saveCustomer({
+    CustomerName: { _cdata: 'MARIO ROSSI & Figli' },
+    CustomerAddress: { _cdata: 'Via Alberti 8' },
+    CustomerPostcode: '06122',
+    CustomerCity: 'Perugia',
+    CustomerProvince: 'PG',
+    CustomerCountry: '',
+    CustomerFiscalCode: 'MARROS66C44G217W',
+    CustomerVatCode: '03912377542',
+    CustomerCellPhone: '335123456789',
+    CustomerEmail: 'info@rossi.it'
+}).then(function( customer ) {
+    console.log( customer );
+}).catch(function( error ) {
+    console.error( error );
+});
+```
+
 ### Create a new invoice
 
 ```js

--- a/src/fattura24.js
+++ b/src/fattura24.js
@@ -135,8 +135,10 @@ Fattura24.prototype.flatObject = function flatObject(object) {
   const flatten = {};
 
   Object.keys(object).forEach((key) => {
-    if (!object[key].text) {
+    if (!object[key].text && !object[key]._cdata) {
       flatten[key] = this.flatObject(object[key]);
+    } else if (object[key]._cdata) {
+      flatten[key] = object[key]._cdata;
     } else {
       flatten[key] = object[key].text;
     }


### PR DESCRIPTION
Quick fix to allow supporting the CDATA elements.

As a matter of fact CDATA is natively supported xml-js lib, the problem arises because the returning XML has also the _cdata object nesting that breaks the actual behaviour (by default it search for a .text object value, while in this case we have a ._cdata object value)

Changed the code and the doc with an example of how to use it for creating customers.